### PR TITLE
fix: geometric annualization in README, relabel drift in experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,13 @@ The Baum-Welch algorithm converges in 73 iterations with a log-likelihood improv
 
 The trained model recovers three economically meaningful regimes:
 
-| State | Label | Daily μ | Ann. Return | Ann. Vol | Stationary Prob | Avg Duration |
-|-------|-------|---------|-------------|----------|-----------------|--------------|
-| 0 | Bearish | -0.058% | -145% | 56.5% | 3.6% | 9 days |
+| State | Label | Daily μ | Ann. Return* | Ann. Vol | Stationary Prob | Avg Duration |
+|-------|-------|---------|--------------|----------|-----------------|--------------|
+| 0 | Bearish | -0.058% | -77% | 56.5% | 3.6% | 9 days |
 | 1 | Neutral | ~0.00% | ~0% | 19.6% | 40.4% | 23 days |
-| 2 | Bullish | +0.11% | +28% | 8.5% | 56.0% | 38 days |
+| 2 | Bullish | +0.11% | +32% | 8.5% | 56.0% | 38 days |
+
+*Annualized return uses geometric compounding: (1 + μ)^252 − 1. The bearish regime lasts ~9 days on average; the annualized figure is a hypothetical extrapolation.*
 
 The bearish state has 7x the volatility of the bullish state, consistent with the leverage effect. The market spends most time in the calm bullish regime (56%).
 

--- a/experiments/03_baum_welch_training.py
+++ b/experiments/03_baum_welch_training.py
@@ -113,11 +113,11 @@ def main():
 
     log("\nEmission parameters:")
     for i in range(K):
-        ann_mu = mu[i] * 252
+        drift_mu = mu[i] * 252
         ann_sigma = sigma[i] * np.sqrt(252)
         log(
             f"  State {i} ({state_labels[i]}): "
-            f"mu = {mu[i]: .6f} (ann. {ann_mu * 100: .2f}%), "
+            f"mu = {mu[i]: .6f} (drift mu*252 = {drift_mu * 100: .2f}%), "
             f"sigma = {sigma[i]: .6f} (ann. {ann_sigma * 100: .2f}%)"
         )
 

--- a/experiments/05_backtest_comparison.py
+++ b/experiments/05_backtest_comparison.py
@@ -136,7 +136,7 @@ def main():
     for i in range(K):
         log(
             f"  State {i} ({labels[i]}): "
-            f"mu = {mu[i]: .6f} (ann. {mu[i] * 252 * 100: .2f}%), "
+            f"mu = {mu[i]: .6f} (drift mu*252 = {mu[i] * 252 * 100: .2f}%), "
             f"sigma = {np.sqrt(sigma2[i]): .6f} (ann. {np.sqrt(sigma2[i]) * np.sqrt(252) * 100: .2f}%)"
         )
 

--- a/experiments/08_k3_vs_k4.py
+++ b/experiments/08_k3_vs_k4.py
@@ -118,11 +118,11 @@ def _save_backtest_figure(test_index, k3_vote_cumulative, k4_vote_cumulative, bh
 def _log_params(log, k, params):
     log(f"\n--- K={k} parameters (sorted by mu) ---")
     for i in range(k):
-        ann_mu = params["mu"][i] * 252.0
+        drift_mu = params["mu"][i] * 252.0
         ann_sigma = np.sqrt(params["sigma2"][i]) * np.sqrt(252.0)
         log(
             f"  state {i}: "
-            f"mu={params['mu'][i]: .6f} (ann. {ann_mu * 100: .2f}%), "
+            f"mu={params['mu'][i]: .6f} (drift mu*252 = {drift_mu * 100: .2f}%), "
             f"sigma={np.sqrt(params['sigma2'][i]): .6f} (ann. {ann_sigma * 100: .2f}%)"
         )
 


### PR DESCRIPTION
## Summary
Closes #39.

- **README table**: switched annualized return column from arithmetic (`μ×252`) to geometric (`(1+μ)^252 − 1`), fixing the misleading -145% bearish figure to -77%. Added footnote explaining the computation.
- **Experiment scripts** (`03`, `05`, `08`): relabeled `ann.` to `drift mu*252` so it's clear the arithmetic scaling is a regime intensity parameter, not a compound return.

## Test plan
- [ ] No code logic changed — purely reporting/labeling fix
- [ ] Verify README table renders correctly
- [ ] Run `pytest -v` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the learned regimes table documentation with clarified "Annualized Return" column, corrected values for Bearish and Bullish regimes, and added explanation of geometric compounding methodology.

* **Refactor**
  * Standardized internal variable naming and log labels across experiment modules for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->