### PR TITLE
fix: Kalman filter review — t=0 prior bug, Joseph form

### DIFF
--- a/src/langevin/kalman.py
+++ b/src/langevin/kalman.py
@@ -55,7 +55,7 @@ def kalman_update(
         S   = G @ C_pred @ G' + sigma_obs^2       innovation covariance  (Eq 31)
         K   = C_pred @ G' / S                      Kalman gain            (Eq 32)
         mu  = mu_pred + K * (y - G @ mu_pred)      filtered mean          (Eq 33)
-        C   = (I - K @ G) @ C_pred                 filtered covariance    (Eq 33)
+        C   = (I-KG) C_pred (I-KG)' + K σ²_obs K'   Joseph form            (Eq 33)
 
     The prediction error decomposition (PED) log-likelihood is:
 
@@ -100,8 +100,12 @@ def kalman_update(
 
     # Filtered state
     mu_new = mu_pred + K * innovation
-    C_new = (np.eye(2) - np.outer(K, G.ravel())) @ C_pred
-    C_new = (C_new + C_new.T) / 2.0  # enforce symmetry
+
+    # Joseph form for numerical stability (PSD-preserving by construction):
+    #   C_new = (I - K G) C_pred (I - K G)' + K sigma_obs^2 K'
+    I_KG = np.eye(2) - np.outer(K, G.ravel())
+    C_new = I_KG @ C_pred @ I_KG.T + sigma_obs_sq * np.outer(K, K)
+    C_new = (C_new + C_new.T) / 2.0  # enforce exact symmetry
 
     # PED log-likelihood: log N(y; y_pred, S)
     log_likelihood = -0.5 * np.log(2.0 * np.pi * S) - 0.5 * innovation**2 / S
@@ -120,7 +124,8 @@ def kalman_filter(
 ) -> tuple[NDArray, NDArray, NDArray, NDArray, NDArray, float]:
     """Run a full Kalman filter over a sequence of observations (2012 Paper §III-A).
 
-    For each timestep t = 0, ..., T-1:
+    For t = 0: use mu0, C0 directly as the predicted state (prior on x_0).
+    For t = 1, ..., T-1:
         1. Predict:  mu_pred, C_pred = kalman_predict(mu_{t-1}, C_{t-1}, F, Q)
         2. Update:   mu_t, C_t, ll_t = kalman_update(mu_pred, C_pred, G, sigma_obs^2, y_t)
 
@@ -144,9 +149,9 @@ def kalman_filter(
     sigma_obs_sq : float
         Observation noise variance.
     mu0 : np.ndarray, shape (2,)
-        Prior state mean.
+        Prior state mean at the time of the first observation.
     C0 : np.ndarray, shape (2, 2)
-        Prior state covariance.
+        Prior state covariance at the time of the first observation.
 
     Returns
     -------
@@ -174,8 +179,11 @@ def kalman_filter(
     C = C0.copy()
 
     for t in range(T):
-        # Predict
-        mu_pred, C_pred = kalman_predict(mu, C, F, Q)
+        # Predict: at t=0 use prior directly; at t>0 propagate through F
+        if t == 0:
+            mu_pred, C_pred = mu.copy(), C.copy()
+        else:
+            mu_pred, C_pred = kalman_predict(mu, C, F, Q)
         predicted_means[t] = mu_pred
         predicted_covs[t] = C_pred
 

--- a/tests/test_kalman.py
+++ b/tests/test_kalman.py
@@ -64,16 +64,16 @@ class TestKalmanPredict:
 class TestKalmanUpdate:
     """Tests for the Kalman update (measurement) step."""
 
-    def test_zero_observation_noise(self):
-        """With sigma_obs=0, posterior collapses to the observation (for price)."""
+    def test_zero_observation_noise_exact(self):
+        """With sigma_obs_sq=0.0 exactly, posterior collapses to the observation."""
         mu_pred = np.array([10.0, 0.5])
         C_pred = np.eye(2)
         G = observation_matrix()
         observation = 12.0
 
-        mu_new, C_new, _ = kalman_update(mu_pred, C_pred, G, 1e-15, observation)
+        mu_new, C_new, _ = kalman_update(mu_pred, C_pred, G, 0.0, observation)
         # Price component should snap to observation
-        np.testing.assert_allclose(mu_new[0], observation, atol=1e-6)
+        np.testing.assert_allclose(mu_new[0], observation, atol=1e-10)
         # Price variance should collapse to ~0
         assert C_new[0, 0] < 1e-10
 
@@ -191,7 +191,7 @@ class TestKalmanFilter:
         assert filt_m.shape == (T, 2)
         assert filt_c.shape == (T, 2, 2)
         assert lls.shape == (T,)
-        assert isinstance(total_ll, float)
+        assert np.isscalar(total_ll)
 
     def test_total_ll_equals_sum(self, synthetic_langevin_data):
         """Total log-likelihood equals sum of per-step PED terms."""
@@ -243,15 +243,65 @@ class TestKalmanFilter:
             assert np.all(eigenvalues >= -1e-12), f"Non-PSD at t={t}"
 
     def test_single_observation(self):
-        """Filter handles T=1 correctly."""
+        """Filter handles T=1 correctly; predicted state at t=0 equals prior."""
         F, Q = discretize_langevin(-0.5, 0.1, 1.0)
         G = observation_matrix()
         mu0 = np.array([10.0, 0.0])
         C0 = np.eye(2) * 5.0
 
-        pred_m, _, filt_m, _, lls, total_ll = kalman_filter(
+        pred_m, pred_c, filt_m, _, lls, total_ll = kalman_filter(
             np.array([10.5]), F, Q, G, 0.5, mu0, C0,
         )
         assert pred_m.shape == (1, 2)
         assert filt_m.shape == (1, 2)
         np.testing.assert_allclose(total_ll, lls[0])
+        # At t=0, predicted state must equal the prior (no spurious predict step)
+        np.testing.assert_allclose(pred_m[0], mu0)
+        np.testing.assert_allclose(pred_c[0], C0)
+
+    def test_prior_used_directly_at_t0(self):
+        """Verify t=0 uses prior directly, not F @ mu0 (catches off-by-one bug)."""
+        F, Q = discretize_langevin(-0.5, 0.1, 1.0)
+        G = observation_matrix()
+        mu0 = np.array([100.0, 0.5])
+        C0 = np.eye(2) * 2.0
+
+        # Use an observation far from the prior so filtered[0] != mu0
+        pred_m, _, filt_m, _, _, _ = kalman_filter(
+            np.array([120.0, 121.0, 122.0]), F, Q, G, 0.5, mu0, C0,
+        )
+        # t=0: prediction = prior
+        np.testing.assert_allclose(pred_m[0], mu0)
+        # After updating with y=120 (far from mu0[0]=100), filtered[0] != mu0
+        assert not np.allclose(filt_m[0], mu0)
+        # t=1 prediction should be F @ filtered[0], not F @ mu0
+        np.testing.assert_allclose(pred_m[1], F @ filt_m[0], atol=1e-12)
+
+    def test_manual_recursion_matches(self):
+        """kalman_filter output matches manual predict-update loop (reference test)."""
+        F, Q = discretize_langevin(-0.3, 0.08, 1.0)
+        G = observation_matrix()
+        sigma_obs_sq = 0.5
+        mu0 = np.array([50.0, 0.1])
+        C0 = np.eye(2) * 3.0
+        obs = np.array([50.5, 51.0, 50.8, 51.2, 50.9])
+
+        # Run kalman_filter
+        pred_m, pred_c, filt_m, filt_c, lls, total_ll = kalman_filter(
+            obs, F, Q, G, sigma_obs_sq, mu0, C0,
+        )
+
+        # Manual loop
+        mu, C = mu0.copy(), C0.copy()
+        for t in range(len(obs)):
+            if t == 0:
+                mp, cp = mu.copy(), C.copy()
+            else:
+                mp, cp = kalman_predict(mu, C, F, Q)
+            np.testing.assert_allclose(pred_m[t], mp, atol=1e-12)
+            np.testing.assert_allclose(pred_c[t], cp, atol=1e-12)
+
+            mu, C, ll = kalman_update(mp, cp, G, sigma_obs_sq, obs[t])
+            np.testing.assert_allclose(filt_m[t], mu, atol=1e-12)
+            np.testing.assert_allclose(filt_c[t], C, atol=1e-12)
+            np.testing.assert_allclose(lls[t], ll, atol=1e-12)


### PR DESCRIPTION
## Summary
Follow-up to PR #52 (Issue #42). Addresses code review findings.

### Critical fixes
- **t=0 prior bug**: `kalman_filter` was applying `kalman_predict(mu0, C0, F, Q)` at t=0, producing `F @ mu0` as the predicted state for the first observation instead of `mu0` directly. Now uses the prior as-is at t=0.
- **Joseph form**: Covariance update switched from `(I-KG) C_pred` (standard form, not PSD-preserving) to `(I-KG) C_pred (I-KG)' + K σ²_obs K'` (Joseph form, PSD-preserving by construction). Critical for RBPF where many Kalman filters run in parallel.

### Test fixes
- `sigma_obs_sq=0.0` tested exactly (not `1e-15`)
- `isinstance → np.isscalar` for type check
- New `test_prior_used_directly_at_t0` verifies the fix
- New `test_manual_recursion_matches` — reference test against manual loop

## Test plan
- [x] 18 tests in `tests/test_kalman.py`, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)