### PR TITLE
exp: Kalman filter intro (experiment 12)

### DIFF
--- a/experiments/12_kalman_filter_intro.py
+++ b/experiments/12_kalman_filter_intro.py
@@ -36,8 +36,8 @@ DT = 1.0            # daily timestep
 T = 500             # number of observations
 SEED = 42           # reproducibility
 
-FIGURES_DIR = Path("figures")
-REPORTS_DIR = Path("reports")
+FIGURES_DIR = PROJECT_ROOT / "figures"
+REPORTS_DIR = PROJECT_ROOT / "reports"
 
 
 def _generate_langevin_data(theta, sigma, sigma_obs, dt, T, rng):
@@ -52,9 +52,6 @@ def _generate_langevin_data(theta, sigma, sigma_obs, dt, T, rng):
     F, Q = discretize_langevin(theta, sigma, dt)
     G = observation_matrix()
 
-    # Cholesky of Q for sampling process noise
-    L_Q = np.linalg.cholesky(Q + 1e-15 * np.eye(2))
-
     true_states = np.zeros((T, 2))
     observations = np.zeros(T)
 
@@ -63,7 +60,9 @@ def _generate_langevin_data(theta, sigma, sigma_obs, dt, T, rng):
 
     for t in range(T):
         if t > 0:
-            w = L_Q @ rng.standard_normal(2)
+            # Q is rank-1 (no direct price noise), so use multivariate_normal
+            # which handles singular covariances via eigendecomposition
+            w = rng.multivariate_normal(np.zeros(2), Q)
             x = F @ x + w
         true_states[t] = x
         observations[t] = (G @ x).item() + sigma_obs * rng.standard_normal()


### PR DESCRIPTION
## Summary
- Synthetic Langevin data generation (no jumps) with known true states
- Kalman filter tracking with 2σ confidence bands
- Residual analysis (standardized innovations vs N(0,1))
- Outputs: `figures/12_kalman_tracking.png`, `figures/12_kalman_residuals.png`, `reports/12_kalman_filter_intro.txt`

## Results
- Trend tracks truth within 2σ for 95.6% of timesteps (>95% required)
- Standardized residuals: mean=-0.04, std=0.97, 4.4% outside ±2

## Test plan
- [x] Runs standalone: `python experiments/12_kalman_filter_intro.py`
- [x] Filtered mean tracks truth within 2σ for >95% of timesteps

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kalman filter experiment that generates synthetic Langevin time-series, runs filtering, and evaluates tracking metrics (RMSE, within-2σ rates) with PASS/WARN status.
  * Includes residual diagnostics (standardized innovations) and produces two visualizations: tracking plot with uncertainty bands and residual histogram/time series.
  * Automatically saves figures and a text report summarizing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->