### PR TITLE
feat: parameter grid search on training-set Sharpe (#66)

### DIFF
--- a/src/langevin/utils.py
+++ b/src/langevin/utils.py
@@ -8,8 +8,13 @@
     Langevin Dynamics", IEEE JSTSP, vol. 6, no. 7, pp. 727-737.
 """
 
+import itertools
+
 import numpy as np
 from numpy.typing import NDArray
+
+from src.langevin.rbpf import run_rbpf
+from src.strategy.backtest import backtest
 
 
 def estimate_langevin_params(
@@ -469,5 +474,236 @@ def igarch_volatility_scale(
         positions[t] = signals[t] / np.sqrt(sigma2)
         # Update variance for next step using current return
         sigma2 = alpha * returns[t] ** 2 + (1.0 - alpha) * sigma2
+
+    return positions
+
+
+def grid_search_params(
+    prices: np.ndarray,
+    param_grid: dict,
+    train_frac: float = 0.7,
+    N_particles: int = 200,
+    dt: float = 1.0,
+    n_taps: int = 4,
+    use_fir: bool = True,
+    transaction_cost_bps: float = 5.0,
+    seed: int = 42,
+) -> dict:
+    """Grid search over RBPF parameters to maximise training-set Sharpe ratio (Paper §IV-C).
+
+    The 2012 paper (§IV-C) states that parameters are "hand-tuned based on
+    measurements of the Sharpe ratio on earlier time periods of data".  This
+    function implements the systematic equivalent: exhaustive grid search over
+    (theta, lambda_J, sigma_J, sigma_delta), evaluating each combination on
+    a training split and reporting overfitting via the train/test Sharpe gap.
+
+    Pipeline for each parameter combination:
+        1. Run RBPF on training prices → filtered trend x2_t            (Paper §III-B)
+        2. FIR smoothing (n_taps=4) on sign(x2_t) → M_t                 (Paper §IV-D)
+           OR direct transfer function trend_to_trading_signal if use_fir=False
+        3. Backtest M_t with transaction_cost_bps → train Sharpe
+
+    The best parameter set is selected by maximum train Sharpe.  Test Sharpe
+    is computed once on the held-out split for the best parameters only, to
+    avoid look-ahead bias through the test set.
+
+    Parameters
+    ----------
+    prices : np.ndarray, shape (T,)
+        Raw price series (or log-price series).  The RBPF is applied directly
+        to this sequence.  For raw prices use estimate_langevin_params_raw()
+        to initialise sigma/sigma_obs; for log-prices use estimate_langevin_params().
+    param_grid : dict
+        Keys must be a subset of: 'theta', 'lambda_J', 'sigma_J', 'sigma_delta',
+        'sigma', 'sigma_obs_sq'.
+        Values are lists of candidate values to evaluate.
+        Parameters not in the grid are derived from the training data via
+        estimate_langevin_params() using the raw returns.
+        Example::
+
+            param_grid = {
+                'theta':       [-0.01, -0.1, -0.5, -1.0],
+                'lambda_J':    [0.0, 0.5, 1.0, 2.0],
+                'sigma_J':     [0.0, 0.01, 0.02],
+                'sigma_delta': [0.001, 0.005, 0.01],
+            }
+
+    train_frac : float
+        Fraction of prices used for training.  Default 0.7 (70/30 split).
+        Must be in (0, 1).
+    N_particles : int
+        Number of RBPF particles per evaluation.  Lower = faster search;
+        higher = lower variance estimates.  Default 200.
+    dt : float
+        Timestep in consistent units (e.g. 1/390 for 1-min bars). Must be > 0.
+    n_taps : int
+        FIR filter length for fir_momentum_signal (used when use_fir=True).
+    use_fir : bool
+        If True, use fir_momentum_signal (Paper §IV-D Steps 1-2).
+        If False, use trend_to_trading_signal with sigma_delta from the grid.
+    transaction_cost_bps : float
+        Round-trip transaction cost in basis points. Must be >= 0.
+    seed : int
+        Base random seed.  Each grid point uses seed + grid_index to ensure
+        reproducibility while avoiding identical RNG states.
+
+    Returns
+    -------
+    result : dict with keys
+        'best_params' : dict
+            Parameter values that achieved the highest training Sharpe.
+            Includes both grid params and data-derived params (sigma, sigma_obs_sq).
+        'best_train_sharpe' : float
+            Sharpe ratio on the training split for the best parameters.
+        'test_sharpe' : float
+            Sharpe ratio on the test split for the best parameters only.
+            Computed once — not used for selection (avoids look-ahead bias).
+        'train_test_gap' : float
+            best_train_sharpe - test_sharpe.  Large positive gap signals overfit.
+        'all_results' : list of dict
+            One entry per grid point, each containing 'params' and 'train_sharpe'.
+            Sorted by descending train_sharpe.
+        'n_evaluated' : int
+            Total number of grid points evaluated.
+
+    Raises
+    ------
+    ValueError
+        If param_grid is empty, train_frac is out of (0, 1), or dt <= 0.
+    """
+    if not param_grid:
+        raise ValueError("param_grid must contain at least one parameter")
+    if not (0.0 < train_frac < 1.0):
+        raise ValueError(f"train_frac must be in (0, 1), got {train_frac}")
+    if dt <= 0:
+        raise ValueError(f"dt must be > 0, got {dt}")
+    if transaction_cost_bps < 0:
+        raise ValueError(f"transaction_cost_bps must be >= 0, got {transaction_cost_bps}")
+    prices = np.asarray(prices, dtype=float)
+    if len(prices) < 10:
+        raise ValueError(f"Need at least 10 prices, got {len(prices)}")
+
+    # ── Train / test split ────────────────────────────────────────────
+    T = len(prices)
+    T_train = int(T * train_frac)
+    train_prices = prices[:T_train]
+    test_prices = prices[T_train:]
+
+    # Returns aligned with prices[1:] (length T-1)
+    train_returns = np.diff(train_prices) / train_prices[:-1]
+    test_returns = np.diff(test_prices) / test_prices[:-1]
+
+    # ── Data-derived defaults (method-of-moments on training data) ────
+    log_returns_train = np.diff(np.log(np.maximum(train_prices, 1e-10)))
+    base_params = estimate_langevin_params(log_returns_train, dt=dt)
+
+    # ── Build Cartesian product of the grid ───────────────────────────
+    grid_keys = list(param_grid.keys())
+    grid_values = [param_grid[k] for k in grid_keys]
+    grid_points = list(itertools.product(*grid_values))
+
+    def _evaluate(point: tuple, prices_eval: np.ndarray, returns_eval: np.ndarray,
+                  point_seed: int) -> float:
+        """Run RBPF + signal pipeline + backtest; return Sharpe."""
+        # Build full parameter dict: grid overrides base_params defaults
+        p = dict(base_params)
+        for key, val in zip(grid_keys, point):
+            p[key] = val
+
+        # sigma_obs_sq may come from the grid directly, or from sigma_obs
+        sigma_obs_sq = p.get('sigma_obs_sq', p['sigma_obs'] ** 2)
+
+        # Stable prior: diffuse price, stationary variance for trend
+        trend_var = p['sigma'] ** 2 / (2.0 * abs(p['theta']))
+        mu0 = np.array([prices_eval[0], 0.0])
+        C0 = np.diag([prices_eval[0] ** 2 * 0.01, trend_var])
+
+        try:
+            filtered_means, _, _, _, _ = run_rbpf(
+                prices_eval,
+                N_particles,
+                theta=p['theta'],
+                sigma=p['sigma'],
+                sigma_obs_sq=sigma_obs_sq,
+                lambda_J=p.get('lambda_J', 0.0),
+                mu_J=p.get('mu_J', 0.0),
+                sigma_J=p.get('sigma_J', 0.0),
+                mu0=mu0,
+                C0=C0,
+                dt=dt,
+                rng=np.random.default_rng(point_seed),
+            )
+        except Exception:
+            return np.nan
+
+        trend = filtered_means[:, 1]  # x2_t
+
+        # Signal pipeline
+        T_eval = len(prices_eval)
+        if use_fir:
+            if len(trend) < n_taps:
+                return np.nan
+            m = fir_momentum_signal(trend, n_taps=n_taps)
+            # Align to full length: prepend n_taps-1 zeros (warmup)
+            signals = np.zeros(T_eval)
+            signals[n_taps - 1:] = m
+        else:
+            sigma_delta = p.get('sigma_delta', 0.005)
+            if len(trend) < 2:
+                return np.nan
+            raw = trend_to_trading_signal(trend, sigma_delta=sigma_delta)
+            signals = np.zeros(T_eval)
+            signals[1:] = raw
+
+        if len(returns_eval) == 0 or np.all(signals == 0):
+            return np.nan
+
+        # Backtest on returns aligned to prices[1:]
+        # signals[t] is based on prices[t], applied to returns[t+1]
+        # backtest() handles the 1-period lag internally
+        signals_bt = signals[:-1]  # drop last (no return after it)
+        result = backtest(returns_eval, signals_bt,
+                          transaction_cost_bps=transaction_cost_bps)
+        sharpe = result['metrics']['sharpe']
+        return sharpe if np.isfinite(sharpe) else np.nan
+
+    # ── Grid search on training data ──────────────────────────────────
+    all_results = []
+    best_train_sharpe = -np.inf
+    best_point = grid_points[0]
+
+    for i, point in enumerate(grid_points):
+        train_sharpe = _evaluate(point, train_prices, train_returns, seed + i)
+        entry = {
+            'params': dict(zip(grid_keys, point)),
+            'train_sharpe': train_sharpe,
+        }
+        all_results.append(entry)
+        if np.isfinite(train_sharpe) and train_sharpe > best_train_sharpe:
+            best_train_sharpe = train_sharpe
+            best_point = point
+
+    # Sort by descending train Sharpe
+    all_results.sort(key=lambda x: x['train_sharpe'] if np.isfinite(x['train_sharpe']) else -np.inf,
+                     reverse=True)
+
+    # ── Evaluate best params on test set (once, no peeking) ──────────
+    best_params_full = dict(base_params)
+    for key, val in zip(grid_keys, best_point):
+        best_params_full[key] = val
+    best_params_full['sigma_obs_sq'] = best_params_full.get(
+        'sigma_obs_sq', best_params_full['sigma_obs'] ** 2
+    )
+
+    test_sharpe = _evaluate(best_point, test_prices, test_returns, seed + len(grid_points))
+
+    return {
+        'best_params': best_params_full,
+        'best_train_sharpe': best_train_sharpe,
+        'test_sharpe': test_sharpe,
+        'train_test_gap': best_train_sharpe - (test_sharpe if np.isfinite(test_sharpe) else 0.0),
+        'all_results': all_results,
+        'n_evaluated': len(grid_points),
+    }
 
     return positions

--- a/src/langevin/utils.py
+++ b/src/langevin/utils.py
@@ -510,9 +510,11 @@ def grid_search_params(
     Parameters
     ----------
     prices : np.ndarray, shape (T,)
-        Raw price series (or log-price series).  The RBPF is applied directly
-        to this sequence.  For raw prices use estimate_langevin_params_raw()
-        to initialise sigma/sigma_obs; for log-prices use estimate_langevin_params().
+        Raw price series (e.g. ES futures closing prices).  Must be in raw
+        (not log) space — the RBPF Kalman state is [price, trend] and the
+        prior C0 = diag([P_0^2 * 0.01, trend_var]) is only meaningful in
+        price units.  Use estimate_langevin_params_raw() to derive sigma and
+        sigma_obs from price differences before customising param_grid.
     param_grid : dict
         Keys must be a subset of: 'theta', 'lambda_J', 'sigma_J', 'sigma_delta',
         'sigma', 'sigma_obs_sq'.
@@ -687,6 +689,14 @@ def grid_search_params(
     all_results.sort(key=lambda x: x['train_sharpe'] if np.isfinite(x['train_sharpe']) else -np.inf,
                      reverse=True)
 
+    if not np.isfinite(best_train_sharpe):
+        raise ValueError(
+            "All grid points returned NaN Sharpe on the training set. "
+            "Check that prices are in raw (not log) space, that N_particles "
+            "is sufficient, and that the parameter ranges in param_grid are valid "
+            "(theta < 0, lambda_J >= 0, sigma_J >= 0)."
+        )
+
     # ── Evaluate best params on test set (once, no peeking) ──────────
     best_params_full = dict(base_params)
     for key, val in zip(grid_keys, best_point):
@@ -701,9 +711,7 @@ def grid_search_params(
         'best_params': best_params_full,
         'best_train_sharpe': best_train_sharpe,
         'test_sharpe': test_sharpe,
-        'train_test_gap': best_train_sharpe - (test_sharpe if np.isfinite(test_sharpe) else 0.0),
+        'train_test_gap': (best_train_sharpe - test_sharpe) if np.isfinite(test_sharpe) else np.nan,
         'all_results': all_results,
         'n_evaluated': len(grid_points),
     }
-
-    return positions

--- a/tests/test_langevin_utils.py
+++ b/tests/test_langevin_utils.py
@@ -7,6 +7,7 @@ from src.langevin.utils import (
     estimate_langevin_params,
     estimate_langevin_params_raw,
     fir_momentum_signal,
+    grid_search_params,
     igarch_volatility_scale,
     trend_to_trading_signal,
 )
@@ -680,3 +681,123 @@ class TestIgarchVolatilityScale:
         returns = np.array([0.0, 0.01, 0.02, 0.01, -0.01])
         with pytest.raises(ValueError, match="First return is zero"):
             igarch_volatility_scale(np.ones(5), returns, sigma2_init=None)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tests for grid_search_params
+# ──────────────────────────────────────────────────────────────────────
+
+def _make_trend_prices(T: int = 300, seed: int = 0) -> np.ndarray:
+    """Synthetic trending price series for grid search tests."""
+    rng = np.random.default_rng(seed)
+    returns = 0.001 + 0.01 * rng.standard_normal(T)
+    prices = 100.0 * np.cumprod(1.0 + returns)
+    return prices
+
+
+class TestGridSearchParams:
+    """Tests for grid_search_params (Paper §IV-C hand-tuning equivalent)."""
+
+    # Tiny grid — 2×2 = 4 points — so tests finish in seconds.
+    SMALL_GRID = {
+        'theta': [-0.1, -1.0],
+        'lambda_J': [0.0, 0.5],
+    }
+
+    def test_returns_expected_keys(self):
+        """Result dict must contain all documented keys."""
+        prices = _make_trend_prices()
+        result = grid_search_params(prices, self.SMALL_GRID, N_particles=50, seed=0)
+        for key in ('best_params', 'best_train_sharpe', 'test_sharpe',
+                    'train_test_gap', 'all_results', 'n_evaluated'):
+            assert key in result, f"missing key '{key}'"
+
+    def test_n_evaluated_equals_grid_size(self):
+        """n_evaluated must equal the Cartesian product of the grid."""
+        prices = _make_trend_prices()
+        result = grid_search_params(prices, self.SMALL_GRID, N_particles=50, seed=0)
+        assert result['n_evaluated'] == 4  # 2 × 2
+
+    def test_all_results_sorted_descending(self):
+        """all_results must be sorted by descending train_sharpe."""
+        prices = _make_trend_prices()
+        result = grid_search_params(prices, self.SMALL_GRID, N_particles=50, seed=0)
+        sharpes = [r['train_sharpe'] for r in result['all_results']
+                   if np.isfinite(r['train_sharpe'])]
+        assert sharpes == sorted(sharpes, reverse=True)
+
+    def test_best_train_sharpe_is_maximum(self):
+        """best_train_sharpe must equal the maximum train_sharpe in all_results."""
+        prices = _make_trend_prices()
+        result = grid_search_params(prices, self.SMALL_GRID, N_particles=50, seed=0)
+        max_sharpe = max(
+            r['train_sharpe'] for r in result['all_results']
+            if np.isfinite(r['train_sharpe'])
+        )
+        np.testing.assert_almost_equal(result['best_train_sharpe'], max_sharpe, decimal=10)
+
+    def test_best_params_contains_grid_keys(self):
+        """best_params must contain all keys that were in the grid."""
+        prices = _make_trend_prices()
+        result = grid_search_params(prices, self.SMALL_GRID, N_particles=50, seed=0)
+        for key in self.SMALL_GRID:
+            assert key in result['best_params'], f"grid key '{key}' missing from best_params"
+
+    def test_best_params_values_in_grid(self):
+        """best_params values for grid keys must be one of the candidate values."""
+        prices = _make_trend_prices()
+        result = grid_search_params(prices, self.SMALL_GRID, N_particles=50, seed=0)
+        for key, candidates in self.SMALL_GRID.items():
+            assert result['best_params'][key] in candidates
+
+    def test_train_test_gap_is_difference(self):
+        """train_test_gap must equal best_train_sharpe - test_sharpe."""
+        prices = _make_trend_prices()
+        result = grid_search_params(prices, self.SMALL_GRID, N_particles=50, seed=0)
+        if np.isfinite(result['test_sharpe']):
+            expected_gap = result['best_train_sharpe'] - result['test_sharpe']
+            np.testing.assert_almost_equal(result['train_test_gap'], expected_gap, decimal=10)
+
+    def test_reproducible_with_same_seed(self):
+        """Same seed must produce identical results."""
+        prices = _make_trend_prices()
+        r1 = grid_search_params(prices, self.SMALL_GRID, N_particles=50, seed=7)
+        r2 = grid_search_params(prices, self.SMALL_GRID, N_particles=50, seed=7)
+        assert r1['best_train_sharpe'] == r2['best_train_sharpe']
+        assert r1['best_params'] == r2['best_params']
+
+    def test_single_grid_point(self):
+        """A grid with one point per parameter must evaluate exactly once."""
+        prices = _make_trend_prices()
+        grid = {'theta': [-0.5], 'lambda_J': [0.0]}
+        result = grid_search_params(prices, grid, N_particles=50, seed=0)
+        assert result['n_evaluated'] == 1
+        assert result['best_params']['theta'] == -0.5
+        assert result['best_params']['lambda_J'] == 0.0
+
+    def test_sigma_delta_in_grid_without_fir(self):
+        """sigma_delta can be grid-searched when use_fir=False."""
+        prices = _make_trend_prices()
+        grid = {'theta': [-0.1, -0.5], 'sigma_delta': [0.001, 0.01]}
+        result = grid_search_params(prices, grid, N_particles=50, use_fir=False, seed=0)
+        assert result['n_evaluated'] == 4
+        assert 'sigma_delta' in result['best_params']
+
+    def test_raises_on_empty_grid(self):
+        """Empty param_grid must raise ValueError."""
+        prices = _make_trend_prices()
+        with pytest.raises(ValueError, match="param_grid"):
+            grid_search_params(prices, {}, N_particles=50)
+
+    def test_raises_on_invalid_train_frac(self):
+        """train_frac outside (0, 1) must raise ValueError."""
+        prices = _make_trend_prices()
+        with pytest.raises(ValueError, match="train_frac"):
+            grid_search_params(prices, self.SMALL_GRID, train_frac=0.0)
+        with pytest.raises(ValueError, match="train_frac"):
+            grid_search_params(prices, self.SMALL_GRID, train_frac=1.0)
+
+    def test_raises_on_too_few_prices(self):
+        """Fewer than 10 prices must raise ValueError."""
+        with pytest.raises(ValueError, match="at least 10"):
+            grid_search_params(np.ones(5), self.SMALL_GRID)

--- a/tests/test_langevin_utils.py
+++ b/tests/test_langevin_utils.py
@@ -750,13 +750,26 @@ class TestGridSearchParams:
         for key, candidates in self.SMALL_GRID.items():
             assert result['best_params'][key] in candidates
 
-    def test_train_test_gap_is_difference(self):
-        """train_test_gap must equal best_train_sharpe - test_sharpe."""
+    def test_train_test_gap_is_difference_when_test_finite(self):
+        """train_test_gap must equal best_train_sharpe - test_sharpe when test is finite."""
         prices = _make_trend_prices()
         result = grid_search_params(prices, self.SMALL_GRID, N_particles=50, seed=0)
         if np.isfinite(result['test_sharpe']):
             expected_gap = result['best_train_sharpe'] - result['test_sharpe']
             np.testing.assert_almost_equal(result['train_test_gap'], expected_gap, decimal=10)
+
+    def test_train_test_gap_is_nan_when_test_sharpe_is_nan(self):
+        """train_test_gap must be NaN when test_sharpe is NaN (not silently 0)."""
+        # Use a test split so short it cannot run the RBPF (< 10 prices).
+        # train_frac=0.97 on 300 prices → test has ~9 prices → _evaluate returns NaN.
+        prices = _make_trend_prices(T=300)
+        result = grid_search_params(prices, self.SMALL_GRID, N_particles=50,
+                                    train_frac=0.97, seed=0)
+        if not np.isfinite(result['test_sharpe']):
+            assert np.isnan(result['train_test_gap']), (
+                "train_test_gap should be NaN when test_sharpe is NaN, "
+                f"got {result['train_test_gap']}"
+            )
 
     def test_reproducible_with_same_seed(self):
         """Same seed must produce identical results."""


### PR DESCRIPTION
## Summary
- Adds `grid_search_params(prices, param_grid, ...)` to `src/langevin/utils.py`
- Exhaustive Cartesian grid over any subset of `theta`, `lambda_J`, `sigma_J`, `sigma_delta`, `sigma`, `sigma_obs_sq`
- Unspecified params filled from `estimate_langevin_params()` on training data
- Pipeline: RBPF → FIR smoothing (or transfer function) → backtest Sharpe
- Test Sharpe evaluated once on held-out split only — not used for selection
- Supports both `use_fir=True` (Paper §IV-D) and `use_fir=False` modes

## Test plan
- [x] 13 tests passing (result keys, grid size, sorting, reproducibility, edge cases)
- [x] `sigma_delta` grid search tested with `use_fir=False`
- [x] Single grid point edge case
- [x] Input validation: empty grid, bad train_frac, too few prices

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a parameter grid search utility to exhaustively evaluate trading strategy parameter combinations and automatically select the best-performing configuration based on training Sharpe ratio.

* **Tests**
  * Added comprehensive test coverage for the new grid search functionality, validating output structure, result ordering, determinism, edge cases, and train/test performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->