### PR TITLE
feat: IOHMM side information — vol ratio, seasonality, bucket-based training

### DIFF
--- a/src/hmm/iohmm.py
+++ b/src/hmm/iohmm.py
@@ -129,7 +129,9 @@ def train_iohmm(
     # Step 4: Train BW per bucket
     bucket_params = []
     bucket_ll = []
-    global_params = None  # Lazy: only train if a bucket needs the fallback
+    # Lazy global fallback: only trained if a bucket has too few observations.
+    global_params = None
+    global_best_ll = float("nan")
 
     for r in range(R):
         mask = bucket_idx == r
@@ -143,14 +145,16 @@ def train_iohmm(
                     f"(< {min_obs_per_bucket}), using global fallback"
                 )
             if global_params is None:
-                global_params, global_ll = train_hmm_numba(
+                global_params, global_ll_hist = train_hmm_numba(
                     observations, K,
                     n_restarts=n_restarts, max_iter=max_iter, tol=tol,
                     min_variance=min_variance, random_state=random_state,
                     verbose=False,
                 )
-            bucket_params.append(global_params)
-            bucket_ll.append(global_ll[-1] if global_params is not None else float("nan"))
+                global_best_ll = global_ll_hist[0]
+            # Copy so each bucket slot owns its own arrays
+            bucket_params.append({k: v.copy() for k, v in global_params.items()})
+            bucket_ll.append(global_best_ll)
             continue
 
         if verbose:
@@ -164,7 +168,7 @@ def train_iohmm(
             verbose=False,
         )
         bucket_params.append(params_r)
-        bucket_ll.append(ll_r[-1])
+        bucket_ll.append(ll_r[0])
 
     return {
         "spline": spline,
@@ -183,12 +187,16 @@ def run_inference_iohmm(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Online predict-update filter with bucket-switching (Paper §6, Algorithm 5).
 
-    At each time step t:
+    At each time step t ≥ 1:
         1. Look up bucket r_t = bucket(x_t) from the side-info spline roots
         2. Retrieve Θ_{r_t} = (A_{r_t}, π_{r_t}, μ_{r_t}, σ²_{r_t})
         3. Predict:  ω̂_t(k) = Σ_i ω_{t-1}(i) · A_{r_t}[i, k]
         4. Forecast: ŷ_t = Σ_k ω̂_t(k) · μ_{r_t}(k)
         5. Update:   ω_t(k) ∝ ω̂_t(k) · N(Δy_t; μ_{r_t}(k), σ²_{r_t}(k))
+
+    At t = 0 there is no prior posterior, so:
+        predictions[0] = Σ_k π_{r_0}(k) · μ_{r_0}(k)   (prior prediction)
+        ω_0(k) ∝ π_{r_0}(k) · N(Δy_0; μ_{r_0}(k), σ²_{r_0}(k))
 
     Parameters
     ----------
@@ -197,14 +205,16 @@ def run_inference_iohmm(
     side_info : np.ndarray, shape (T,)
         Side information x_1, ..., x_T.
     iohmm_params : dict
-        Output from train_iohmm().
+        Output from train_iohmm().  Required keys:
+        "boundaries", "bucket_params", "K", "R".
 
     Returns
     -------
     predictions : np.ndarray, shape (T,)
-        One-step-ahead predictions ŷ_t = E[Δy_t | Δy_{1:t-1}, x_t].
+        predictions[0] = E[Δy_0 | x_0]  (unconditional prior prediction).
+        predictions[t] = E[Δy_t | Δy_{0:t-1}, x_t]  for t ≥ 1.
     state_probs : np.ndarray, shape (T, K)
-        Filtered state posteriors p(m_t | Δy_{1:t}, x_{1:t}).
+        Filtered state posteriors p(m_t | Δy_{0:t}, x_{0:t}).
     """
     observations = np.asarray(observations, dtype=np.float64)
     side_info = np.asarray(side_info, dtype=np.float64)
@@ -219,10 +229,21 @@ def run_inference_iohmm(
             f"got {len(observations)} and {len(side_info)}"
         )
 
+    # Validate iohmm_params structure
+    required_keys = {"boundaries", "bucket_params", "K", "R"}
+    missing = required_keys - set(iohmm_params)
+    if missing:
+        raise ValueError(f"iohmm_params is missing keys: {missing}")
+
     boundaries = iohmm_params["boundaries"]
     bucket_params = iohmm_params["bucket_params"]
     K = iohmm_params["K"]
     R = iohmm_params["R"]
+
+    if len(bucket_params) != R:
+        raise ValueError(
+            f"bucket_params length {len(bucket_params)} != R={R}"
+        )
 
     # Assign observations to buckets via the trained spline boundaries
     bucket_idx = np.searchsorted(boundaries, side_info, side="right").astype(np.intp)

--- a/src/hmm/iohmm.py
+++ b/src/hmm/iohmm.py
@@ -1,0 +1,297 @@
+"""Input-Output HMM — bucket-based training + inference (Paper §5-6).
+
+The IOHMM conditions the HMM parameters on extrinsic side information x_t
+(volatility ratio or intraday seasonality).  The side info is discretized
+into R buckets via B-spline roots (Algorithm 3), and a separate HMM is
+trained per bucket using standard Baum-Welch.
+
+At inference time (Algorithm 5), the predict-update filter selects
+parameters Θ_{r_t} based on which bucket the current side info x_t falls in.
+
+    ω̂_t(k) = Σ_i ω_{t-1}(i) · A_{r_t}[i, k]      (predict with bucket A)
+    ŷ_t   = Σ_k ω̂_t(k) · μ_{r_t}(k)               (one-step-ahead prediction)
+    ω_t(k) ∝ ω̂_t(k) · N(Δy_t; μ_{r_t}(k), σ²_{r_t}(k))  (update)
+
+Note: this implementation trains *fully separate* HMMs per bucket (each with
+its own A, pi, mu, sigma2).  A more refined approach would share emission
+parameters across buckets and only vary the transition matrix — this is left
+as a possible extension.
+
+Public API
+----------
+train_iohmm(obs, side_info, K, ...) -> dict
+    Bucket-based BW training.  Returns spline + per-bucket parameters.
+
+run_inference_iohmm(obs, side_info, iohmm_params) -> predictions, state_probs
+    Online inference with bucket-switching.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.special import logsumexp
+
+from src.hmm.baum_welch_numba import train_hmm_numba
+from src.hmm.side_info import fit_spline, spline_buckets
+
+
+def train_iohmm(
+    observations: np.ndarray,
+    side_info: np.ndarray,
+    K: int,
+    *,
+    n_knots: int = 6,
+    min_obs_per_bucket: int | None = None,
+    n_restarts: int = 10,
+    max_iter: int = 200,
+    tol: float = 1e-6,
+    min_variance: float = 1e-8,
+    random_state: int = 42,
+    verbose: bool = False,
+) -> dict:
+    """Train IOHMM via bucket-based Baum-Welch (Paper §5, Algorithm 3).
+
+    Algorithm:
+        1. Fit B-spline G(x) to (side_info, observations)   (§4.1, Algorithm 2)
+        2. Find roots of G → R bucket boundaries              (§5, Alg 3 line 1)
+        3. Map observations to buckets: Z_t = bucket(x_t)     (§5, Alg 3 line 2)
+        4. For each bucket r ∈ {0, ..., R-1}:
+             Θ_r = BaumWelch(obs[Z == r], K)                  (§5, Alg 3 line 3)
+
+    Buckets with fewer than *min_obs_per_bucket* observations fall back
+    to parameters trained on the full dataset.
+
+    Parameters
+    ----------
+    observations : np.ndarray, shape (T,)
+        Log-returns Δy_1, ..., Δy_T.
+    side_info : np.ndarray, shape (T,)
+        Extrinsic predictor values x_1, ..., x_T (vol ratio or time-of-day).
+    K : int
+        Number of hidden states.
+    n_knots : int
+        Number of interior knots for B-spline (Paper: 6 for vol ratio).
+    min_obs_per_bucket : int or None
+        Minimum observations required per bucket.  Buckets with fewer
+        observations fall back to global (full-data) parameters.
+        Default: max(2·K, 10).
+    n_restarts : int
+        BW restarts per bucket.
+    max_iter : int
+        Max BW iterations per restart.
+    tol : float
+        BW convergence tolerance.
+    min_variance : float
+        Variance floor for emissions.
+    random_state : int
+        RNG seed.
+    verbose : bool
+        Print training progress.
+
+    Returns
+    -------
+    iohmm_params : dict
+        "spline"        : fitted BSpline object
+        "boundaries"    : np.ndarray, shape (n_roots,) — bucket boundaries
+        "bucket_params" : list of R dicts, each with "A", "pi", "mu", "sigma2"
+        "bucket_ll"     : list of R floats — final log-likelihood per bucket
+        "K"             : int — number of states
+        "R"             : int — number of buckets
+    """
+    observations = np.asarray(observations, dtype=np.float64)
+    side_info = np.asarray(side_info, dtype=np.float64)
+
+    if observations.ndim != 1 or observations.size == 0:
+        raise ValueError("observations must be a non-empty 1D array")
+    if side_info.ndim != 1:
+        raise ValueError("side_info must be a 1D array")
+    if len(observations) != len(side_info):
+        raise ValueError(
+            f"observations and side_info must have same length, "
+            f"got {len(observations)} and {len(side_info)}"
+        )
+    if K < 1:
+        raise ValueError(f"K must be >= 1, got {K}")
+
+    if min_obs_per_bucket is None:
+        min_obs_per_bucket = max(2 * K, 10)
+
+    # Step 1: Fit spline G(x) to (side_info, observations)
+    spline = fit_spline(side_info, observations, n_knots=n_knots)
+
+    # Step 2-3: Find roots → buckets, assign observations
+    boundaries, bucket_idx = spline_buckets(spline, side_info)
+    R = len(boundaries) + 1
+
+    if verbose:
+        print(f"IOHMM: {R} buckets from {len(boundaries)} spline roots")
+
+    # Step 4: Train BW per bucket
+    bucket_params = []
+    bucket_ll = []
+    global_params = None  # Lazy: only train if a bucket needs the fallback
+
+    for r in range(R):
+        mask = bucket_idx == r
+        obs_r = observations[mask]
+
+        if len(obs_r) < min_obs_per_bucket:
+            # Too few observations — fall back to global parameters
+            if verbose:
+                print(
+                    f"  bucket {r}: {len(obs_r)} obs "
+                    f"(< {min_obs_per_bucket}), using global fallback"
+                )
+            if global_params is None:
+                global_params, global_ll = train_hmm_numba(
+                    observations, K,
+                    n_restarts=n_restarts, max_iter=max_iter, tol=tol,
+                    min_variance=min_variance, random_state=random_state,
+                    verbose=False,
+                )
+            bucket_params.append(global_params)
+            bucket_ll.append(global_ll[-1] if global_params is not None else float("nan"))
+            continue
+
+        if verbose:
+            print(f"  bucket {r}: {len(obs_r)} obs — training BW")
+
+        params_r, ll_r = train_hmm_numba(
+            obs_r, K,
+            n_restarts=n_restarts, max_iter=max_iter, tol=tol,
+            min_variance=min_variance,
+            random_state=random_state + r,
+            verbose=False,
+        )
+        bucket_params.append(params_r)
+        bucket_ll.append(ll_r[-1])
+
+    return {
+        "spline": spline,
+        "boundaries": boundaries,
+        "bucket_params": bucket_params,
+        "bucket_ll": bucket_ll,
+        "K": K,
+        "R": R,
+    }
+
+
+def run_inference_iohmm(
+    observations: np.ndarray,
+    side_info: np.ndarray,
+    iohmm_params: dict,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Online predict-update filter with bucket-switching (Paper §6, Algorithm 5).
+
+    At each time step t:
+        1. Look up bucket r_t = bucket(x_t) from the side-info spline roots
+        2. Retrieve Θ_{r_t} = (A_{r_t}, π_{r_t}, μ_{r_t}, σ²_{r_t})
+        3. Predict:  ω̂_t(k) = Σ_i ω_{t-1}(i) · A_{r_t}[i, k]
+        4. Forecast: ŷ_t = Σ_k ω̂_t(k) · μ_{r_t}(k)
+        5. Update:   ω_t(k) ∝ ω̂_t(k) · N(Δy_t; μ_{r_t}(k), σ²_{r_t}(k))
+
+    Parameters
+    ----------
+    observations : np.ndarray, shape (T,)
+        Log-returns Δy_1, ..., Δy_T.
+    side_info : np.ndarray, shape (T,)
+        Side information x_1, ..., x_T.
+    iohmm_params : dict
+        Output from train_iohmm().
+
+    Returns
+    -------
+    predictions : np.ndarray, shape (T,)
+        One-step-ahead predictions ŷ_t = E[Δy_t | Δy_{1:t-1}, x_t].
+    state_probs : np.ndarray, shape (T, K)
+        Filtered state posteriors p(m_t | Δy_{1:t}, x_{1:t}).
+    """
+    observations = np.asarray(observations, dtype=np.float64)
+    side_info = np.asarray(side_info, dtype=np.float64)
+
+    if observations.ndim != 1 or observations.size == 0:
+        raise ValueError("observations must be a non-empty 1D array")
+    if side_info.ndim != 1:
+        raise ValueError("side_info must be a 1D array")
+    if len(observations) != len(side_info):
+        raise ValueError(
+            f"observations and side_info must have same length, "
+            f"got {len(observations)} and {len(side_info)}"
+        )
+
+    boundaries = iohmm_params["boundaries"]
+    bucket_params = iohmm_params["bucket_params"]
+    K = iohmm_params["K"]
+    R = iohmm_params["R"]
+
+    # Assign observations to buckets via the trained spline boundaries
+    bucket_idx = np.searchsorted(boundaries, side_info, side="right").astype(np.intp)
+    # Clamp to valid range [0, R-1]
+    np.clip(bucket_idx, 0, R - 1, out=bucket_idx)
+
+    T = len(observations)
+    predictions = np.empty(T)
+    state_probs = np.empty((T, K))
+
+    # ── t = 0: use pi from bucket r_0 ───────────────────────────────────────
+    r0 = bucket_idx[0]
+    p0 = bucket_params[r0]
+    pi = p0["pi"]
+    mu = p0["mu"]
+    sigma2 = p0["sigma2"]
+
+    predictions[0] = float(np.dot(pi, mu))
+
+    log_omega = np.log(pi) + _log_gauss_vec(observations[0], mu, sigma2)
+    log_omega -= logsumexp(log_omega)
+    omega = np.exp(log_omega)
+    state_probs[0] = omega
+
+    # ── t ≥ 1: predict-update with bucket-dependent parameters ──────────────
+    for t in range(1, T):
+        r_t = bucket_idx[t]
+        p_t = bucket_params[r_t]
+        A_t = p_t["A"]
+        mu_t = p_t["mu"]
+        sigma2_t = p_t["sigma2"]
+
+        # Predict: ω̂_t = ω_{t-1} · A_{r_t}
+        omega_pred = omega @ A_t
+
+        # One-step-ahead prediction: ŷ_t = Σ_k ω̂_t(k) · μ_{r_t}(k)
+        predictions[t] = float(np.dot(omega_pred, mu_t))
+
+        # Update: ω_t(k) ∝ ω̂_t(k) · N(Δy_t; μ_{r_t}(k), σ²_{r_t}(k))
+        log_omega = (
+            np.log(np.maximum(omega_pred, 1e-300))
+            + _log_gauss_vec(observations[t], mu_t, sigma2_t)
+        )
+        log_omega -= logsumexp(log_omega)
+        omega = np.exp(log_omega)
+        state_probs[t] = omega
+
+    return predictions, state_probs
+
+
+def _log_gauss_vec(
+    x: float,
+    mu: np.ndarray,
+    sigma2: np.ndarray,
+) -> np.ndarray:
+    """log N(x; μ_k, σ²_k) for each state k — vectorized.
+
+    Parameters
+    ----------
+    x : float
+        Observation.
+    mu : np.ndarray, shape (K,)
+        Emission means.
+    sigma2 : np.ndarray, shape (K,)
+        Emission variances (must be > 0).
+
+    Returns
+    -------
+    log_pdf : np.ndarray, shape (K,)
+        log N(x; μ_k, σ²_k) for k = 0, ..., K-1.
+    """
+    return -0.5 * np.log(2.0 * np.pi * sigma2) - 0.5 * (x - mu) ** 2 / sigma2

--- a/src/hmm/side_info.py
+++ b/src/hmm/side_info.py
@@ -1,0 +1,322 @@
+"""Side information features for IOHMM — volatility ratio + seasonality (Paper §4).
+
+The paper introduces two extrinsic predictors that condition the IOHMM's
+transition matrix, boosting Sharpe from ~0.5 (HMM alone) to ~2.0:
+
+1. Volatility ratio (§4.2): x_t = σ_{short}(t) / σ_{long}(t)
+   where σ is estimated via IGARCH(1,1) / EWMA (Eq. 4).
+   Economic meaning: ratio < 0.6 → risk falling → buy;
+                      ratio > 0.8 → risk rising → sell.
+
+2. Intraday seasonality (§4.3): x_t = normalized time-of-day ∈ [0, 1].
+   The paper finds: buy early morning, sell afternoon.
+
+Both features are fed into B-splines (§4.1) to capture their non-linear
+relationship with future returns. Spline roots discretize the feature space
+into R buckets for the IOHMM (§5, Algorithm 3).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.interpolate import make_lsq_spline
+
+
+def ewma_volatility(
+    returns: np.ndarray,
+    lam: float = 0.79,
+    window: int | None = None,
+) -> np.ndarray:
+    """EWMA volatility estimate (Paper §4.2, Eq. 4).
+
+    σ_{t+1|t} = sqrt((1 - λ) · Σ_{τ=0}^{Ω-1} λ^τ · Δy²_{t-τ})
+
+    This is IGARCH(1,1) / J.P. Morgan RiskMetrics. The paper uses λ=0.79
+    for 1-min data (more reactive than the daily default of λ=0.94).
+
+    The recursion is:
+        σ²_{t+1|t} = λ · σ²_{t|t-1} + (1 - λ) · Δy²_t
+
+    Parameters
+    ----------
+    returns : np.ndarray, shape (T,)
+        Log-returns Δy_1, ..., Δy_T.
+    lam : float
+        Decay factor λ ∈ (0, 1). Paper §4.2: λ=0.79 for 1-min data.
+    window : int or None
+        If given, use only the last `window` observations for each estimate.
+        If None, use the full history (infinite window).
+
+    Returns
+    -------
+    sigma : np.ndarray, shape (T,)
+        Conditional volatility estimates σ_{t+1|t} for t = 1, ..., T.
+        sigma[t] is the forecast for time t+1, based on data up to time t.
+    """
+    if len(returns) < 1:
+        raise ValueError(f"returns must have at least 1 observation, got {len(returns)}")
+    if not (0.0 < lam < 1.0):
+        raise ValueError(f"lam must be in (0, 1), got {lam}")
+
+    returns = np.asarray(returns, dtype=np.float64)
+    T = len(returns)
+    sigma2 = np.empty(T)
+
+    # Initialize with first squared return
+    sigma2[0] = returns[0] ** 2
+    if sigma2[0] == 0.0:
+        sigma2[0] = np.mean(returns ** 2) if T > 1 else 1e-10
+
+    # EWMA recursion: σ²_{t+1} = λ·σ²_t + (1-λ)·Δy²_t
+    for t in range(1, T):
+        sigma2[t] = lam * sigma2[t - 1] + (1 - lam) * returns[t] ** 2
+
+    # Apply finite window by re-initializing if needed
+    if window is not None and window < T:
+        if window < 1:
+            raise ValueError(f"window must be >= 1, got {window}")
+        # Re-compute with window-limited sums
+        for t in range(T):
+            start = max(0, t - window + 1)
+            weights = lam ** np.arange(t - start, -1, -1)
+            sigma2[t] = (1 - lam) * np.sum(weights * returns[start:t + 1] ** 2)
+            if sigma2[t] == 0.0:
+                sigma2[t] = 1e-10
+
+    return np.sqrt(np.maximum(sigma2, 0.0))
+
+
+def volatility_ratio(
+    returns: np.ndarray,
+    window_short: int = 50,
+    window_long: int = 100,
+    lam: float = 0.79,
+) -> np.ndarray:
+    """Ratio of short-window to long-window EWMA volatility (Paper §4.2).
+
+    x_t = σ_{t+1|t}(Ω_fast) / σ_{t+1|t}(Ω_slow)
+
+    The paper sweeps parameters and selects Ω_fast=50, Ω_slow=100.
+
+    Economic interpretation:
+        x_t < 0.6 → recent vol falling relative to history → risk falling → buy
+        x_t > 0.8 → recent vol rising relative to history → risk rising → sell
+
+    Parameters
+    ----------
+    returns : np.ndarray, shape (T,)
+        Log-returns.
+    window_short : int
+        Short EWMA window Ω_fast (Paper: 50).
+    window_long : int
+        Long EWMA window Ω_slow (Paper: 100).
+    lam : float
+        EWMA decay factor λ (Paper: 0.79).
+
+    Returns
+    -------
+    ratio : np.ndarray, shape (T,)
+        Volatility ratio x_t = σ_short / σ_long. Values in (0, ∞).
+    """
+    if window_short >= window_long:
+        raise ValueError(
+            f"window_short ({window_short}) must be < window_long ({window_long})"
+        )
+    sigma_short = ewma_volatility(returns, lam=lam, window=window_short)
+    sigma_long = ewma_volatility(returns, lam=lam, window=window_long)
+    # Avoid division by zero
+    sigma_long = np.maximum(sigma_long, 1e-15)
+    return sigma_short / sigma_long
+
+
+def seasonality_feature(
+    timestamps: np.ndarray,
+    market_open_minutes: int = 0,
+    market_close_minutes: int = 390,
+) -> np.ndarray:
+    """Normalized time-of-day feature ∈ [0, 1] (Paper §4.3).
+
+    x_t = (minutes_since_midnight(t) - market_open) / (market_close - market_open)
+
+    For ES RTH: open=09:30 ET (570 min), close=16:00 ET (960 min).
+
+    Parameters
+    ----------
+    timestamps : array-like
+        DatetimeIndex or array of datetime-like objects.
+    market_open_minutes : int
+        Market open as minutes since midnight (default 0 = use raw hour/minute).
+    market_close_minutes : int
+        Market close as minutes since midnight (default 390 = 6.5h session).
+
+    Returns
+    -------
+    feature : np.ndarray, shape (T,)
+        Normalized time-of-day ∈ [0, 1].
+    """
+    import pandas as pd
+
+    ts = pd.DatetimeIndex(timestamps)
+    minutes = ts.hour * 60 + ts.minute
+
+    if market_open_minutes == 0 and market_close_minutes == 390:
+        # Auto-detect: use min/max of observed minutes
+        market_open_minutes = int(minutes.min())
+        market_close_minutes = int(minutes.max())
+
+    span = market_close_minutes - market_open_minutes
+    if span <= 0:
+        raise ValueError(
+            f"market_close ({market_close_minutes}) must be > market_open ({market_open_minutes})"
+        )
+
+    feature = (minutes - market_open_minutes) / span
+    return np.clip(feature.values.astype(np.float64), 0.0, 1.0)
+
+
+def fit_spline(
+    x: np.ndarray,
+    y: np.ndarray,
+    n_knots: int = 6,
+    degree: int = 3,
+) -> object:
+    """Fit a zero-mean B-spline to (x, y) pairs (Paper §4.1, Algorithm 2).
+
+    The paper (§4.1): "Each spline is forced to be zero mean by setting
+    the integral of the spline to be zero."
+
+    Uses scipy's make_lsq_spline for least-squares B-spline fitting.
+
+    Parameters
+    ----------
+    x : np.ndarray, shape (T,)
+        Predictor values (vol ratio or time-of-day).
+    y : np.ndarray, shape (T,)
+        Normalized returns ȳ (zero mean, unit variance).
+    n_knots : int
+        Number of interior knots. Paper: 6 for vol ratio, 10 for seasonality.
+    degree : int
+        B-spline degree (default 3 = cubic).
+
+    Returns
+    -------
+    spline : BSpline
+        Fitted B-spline callable: spline(x_new) → predicted return.
+    """
+    if len(x) != len(y):
+        raise ValueError(f"x and y must have same length, got {len(x)} and {len(y)}")
+    if len(x) < n_knots + degree + 1:
+        raise ValueError(
+            f"Need at least {n_knots + degree + 1} observations for {n_knots} knots, "
+            f"got {len(x)}"
+        )
+
+    x = np.asarray(x, dtype=np.float64)
+    y = np.asarray(y, dtype=np.float64)
+
+    # Sort by x for spline fitting
+    order = np.argsort(x)
+    x_sorted = x[order]
+    y_sorted = y[order]
+
+    # Interior knots: evenly spaced quantiles
+    knot_positions = np.linspace(0, 1, n_knots + 2)[1:-1]
+    interior_knots = np.quantile(x_sorted, knot_positions)
+
+    # Full knot vector: degree+1 copies of endpoints + interior knots
+    t = np.concatenate([
+        np.full(degree + 1, x_sorted[0]),
+        interior_knots,
+        np.full(degree + 1, x_sorted[-1]),
+    ])
+
+    spline = make_lsq_spline(x_sorted, y_sorted, t, k=degree)
+
+    # Zero-mean correction: subtract mean of spline over data range
+    # "the integral of the spline to be zero" (Paper §4.1)
+    x_eval = np.linspace(x_sorted[0], x_sorted[-1], 1000)
+    spline_mean = np.mean(spline(x_eval))
+    spline.c -= spline_mean
+
+    return spline
+
+
+def evaluate_spline(spline, x_new: np.ndarray) -> np.ndarray:
+    """Evaluate fitted spline on new data (Paper §4.1, Algorithm 2 line 9).
+
+    ŷ_t = G(x_t)
+
+    Parameters
+    ----------
+    spline : BSpline
+        Fitted spline from fit_spline().
+    x_new : np.ndarray, shape (T,)
+        New predictor values.
+
+    Returns
+    -------
+    signal : np.ndarray, shape (T,)
+        Predicted return signal.
+    """
+    x_new = np.asarray(x_new, dtype=np.float64)
+    # Clip to spline domain to avoid extrapolation
+    x_lo = spline.t[0]
+    x_hi = spline.t[-1]
+    x_clipped = np.clip(x_new, x_lo, x_hi)
+    return spline(x_clipped)
+
+
+def spline_buckets(
+    spline,
+    x: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Find spline roots → R buckets, assign x values to buckets (Paper §5, Algorithm 3).
+
+    From the paper (§5): "discretizing the spline according to its roots,
+    with R-1 roots giving R 'buckets' of spline."
+
+    Algorithm 3, line 1: R = NewtonRaphson(G)  {Find the roots of spline G}
+    Algorithm 3, line 2: Z_{1:R} = map(Y, X, R)  {Map Y to buckets}
+
+    Parameters
+    ----------
+    spline : BSpline
+        Fitted spline from fit_spline().
+    x : np.ndarray, shape (T,)
+        Feature values to assign to buckets.
+
+    Returns
+    -------
+    boundaries : np.ndarray, shape (n_roots,)
+        Spline root positions (bucket boundaries), sorted.
+    bucket_indices : np.ndarray, shape (T,), dtype int
+        Bucket index for each observation (0, 1, ..., R-1).
+    """
+    x = np.asarray(x, dtype=np.float64)
+
+    # Find roots by evaluating spline on a fine grid and detecting sign changes
+    x_lo = spline.t[0]
+    x_hi = spline.t[-1]
+    x_grid = np.linspace(x_lo, x_hi, 10000)
+    y_grid = spline(x_grid)
+
+    # Detect sign changes
+    sign_changes = np.where(np.diff(np.sign(y_grid)))[0]
+    roots = []
+    for idx in sign_changes:
+        # Linear interpolation to find root
+        x0, x1 = x_grid[idx], x_grid[idx + 1]
+        y0, y1 = y_grid[idx], y_grid[idx + 1]
+        if y1 != y0:
+            root = x0 - y0 * (x1 - x0) / (y1 - y0)
+            roots.append(root)
+
+    boundaries = np.array(sorted(set(np.round(roots, 10))))
+
+    # Assign to buckets using np.searchsorted
+    # Bucket 0: x < boundaries[0]
+    # Bucket r: boundaries[r-1] <= x < boundaries[r]
+    # Bucket R-1: x >= boundaries[-1]
+    bucket_indices = np.searchsorted(boundaries, x, side="right").astype(np.intp)
+
+    return boundaries, bucket_indices

--- a/tests/test_iohmm.py
+++ b/tests/test_iohmm.py
@@ -1,0 +1,263 @@
+"""Tests for IOHMM — bucket-based training + inference (Paper §5-6)."""
+
+import numpy as np
+import pytest
+
+from src.hmm.iohmm import (
+    _log_gauss_vec,
+    run_inference_iohmm,
+    train_iohmm,
+)
+
+# ── Shared fixtures ──────────────────────────────────────────────────────────
+
+# Small synthetic data with two regimes correlated with side info
+RNG = np.random.default_rng(42)
+T_SYNTH = 500
+# Side info: linearly increasing from 0 to 1
+SIDE_INFO_SYNTH = np.linspace(0.2, 0.8, T_SYNTH)
+# Returns: bearish when side_info < 0.5, bullish when side_info >= 0.5
+OBS_SYNTH = np.where(
+    SIDE_INFO_SYNTH < 0.5,
+    RNG.normal(-0.002, 0.005, T_SYNTH),
+    RNG.normal(+0.002, 0.005, T_SYNTH),
+)
+
+# BW settings for fast tests
+FAST_BW = dict(n_restarts=2, max_iter=50, tol=1e-4, min_variance=1e-8)
+
+
+# ── _log_gauss_vec ───────────────────────────────────────────────────────────
+
+
+class TestLogGaussVec:
+    def test_known_values(self):
+        """Standard normal at x=0 should give log(1/√(2π))."""
+        result = _log_gauss_vec(0.0, np.array([0.0]), np.array([1.0]))
+        expected = -0.5 * np.log(2 * np.pi)
+        np.testing.assert_allclose(result, [expected], rtol=1e-12)
+
+    def test_vector_output(self):
+        mu = np.array([-1.0, 0.0, 1.0])
+        sigma2 = np.array([0.5, 1.0, 2.0])
+        result = _log_gauss_vec(0.5, mu, sigma2)
+        assert result.shape == (3,)
+        assert np.all(np.isfinite(result))
+        # All log-densities should be negative (density < 1 for these params)
+        assert np.all(result < 0)
+
+
+# ── train_iohmm ─────────────────────────────────────────────────────────────
+
+
+class TestTrainIohmm:
+    def test_output_keys(self):
+        """All expected keys must be present in the output dict."""
+        result = train_iohmm(
+            OBS_SYNTH, SIDE_INFO_SYNTH, K=2, n_knots=4, **FAST_BW,
+        )
+        expected_keys = {"spline", "boundaries", "bucket_params", "bucket_ll", "K", "R"}
+        assert set(result.keys()) == expected_keys
+
+    def test_bucket_count_consistent(self):
+        """R must equal len(boundaries) + 1."""
+        result = train_iohmm(
+            OBS_SYNTH, SIDE_INFO_SYNTH, K=2, n_knots=4, **FAST_BW,
+        )
+        assert result["R"] == len(result["boundaries"]) + 1
+        assert len(result["bucket_params"]) == result["R"]
+        assert len(result["bucket_ll"]) == result["R"]
+
+    def test_bucket_params_valid_hmms(self):
+        """Each bucket's parameters must form a valid HMM."""
+        result = train_iohmm(
+            OBS_SYNTH, SIDE_INFO_SYNTH, K=2, n_knots=4, **FAST_BW,
+        )
+        K = result["K"]
+        for r, params in enumerate(result["bucket_params"]):
+            # Check shapes
+            assert params["A"].shape == (K, K), f"bucket {r}: A wrong shape"
+            assert params["pi"].shape == (K,), f"bucket {r}: pi wrong shape"
+            assert params["mu"].shape == (K,), f"bucket {r}: mu wrong shape"
+            assert params["sigma2"].shape == (K,), f"bucket {r}: sigma2 wrong shape"
+
+            # Transition matrix: rows sum to 1
+            row_sums = params["A"].sum(axis=1)
+            np.testing.assert_allclose(
+                row_sums, np.ones(K),
+                atol=K * np.finfo(float).eps,
+                err_msg=f"bucket {r}: A rows don't sum to 1",
+            )
+
+            # Initial distribution sums to 1
+            assert params["pi"].sum() == pytest.approx(1.0, abs=1e-10)
+
+            # Positive variances
+            assert np.all(params["sigma2"] > 0), f"bucket {r}: non-positive sigma2"
+
+            # States sorted by ascending mu
+            assert np.all(np.diff(params["mu"]) >= 0), f"bucket {r}: mu not sorted"
+
+    def test_K_preserved(self):
+        result = train_iohmm(
+            OBS_SYNTH, SIDE_INFO_SYNTH, K=3, n_knots=4, **FAST_BW,
+        )
+        assert result["K"] == 3
+        for params in result["bucket_params"]:
+            assert params["mu"].shape == (3,)
+
+    def test_fallback_for_sparse_bucket(self):
+        """Buckets with too few observations should use global fallback."""
+        # Use very high min_obs_per_bucket so ALL buckets fall back
+        result = train_iohmm(
+            OBS_SYNTH, SIDE_INFO_SYNTH, K=2, n_knots=4,
+            min_obs_per_bucket=T_SYNTH + 1,  # impossible threshold
+            **FAST_BW,
+        )
+        # All buckets should have identical parameters (global fallback)
+        for r in range(1, result["R"]):
+            np.testing.assert_array_equal(
+                result["bucket_params"][r]["mu"],
+                result["bucket_params"][0]["mu"],
+            )
+
+    def test_bucket_ll_finite(self):
+        result = train_iohmm(
+            OBS_SYNTH, SIDE_INFO_SYNTH, K=2, n_knots=4, **FAST_BW,
+        )
+        for ll in result["bucket_ll"]:
+            assert np.isfinite(ll)
+
+    def test_input_validation_length_mismatch(self):
+        with pytest.raises(ValueError, match="same length"):
+            train_iohmm(np.array([1.0, 2.0]), np.array([1.0]), K=2)
+
+    def test_input_validation_empty(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            train_iohmm(np.array([]), np.array([]), K=2)
+
+    def test_input_validation_K(self):
+        with pytest.raises(ValueError, match="K must be"):
+            train_iohmm(OBS_SYNTH, SIDE_INFO_SYNTH, K=0)
+
+
+# ── run_inference_iohmm ─────────────────────────────────────────────────────
+
+
+class TestRunInferenceIohmm:
+    @pytest.fixture()
+    def trained_model(self):
+        return train_iohmm(
+            OBS_SYNTH, SIDE_INFO_SYNTH, K=2, n_knots=4, **FAST_BW,
+        )
+
+    def test_output_shapes(self, trained_model):
+        preds, sprobs = run_inference_iohmm(
+            OBS_SYNTH, SIDE_INFO_SYNTH, trained_model,
+        )
+        assert preds.shape == (T_SYNTH,)
+        assert sprobs.shape == (T_SYNTH, 2)
+
+    def test_predictions_finite(self, trained_model):
+        preds, _ = run_inference_iohmm(
+            OBS_SYNTH, SIDE_INFO_SYNTH, trained_model,
+        )
+        assert np.all(np.isfinite(preds))
+
+    def test_state_probs_sum_to_one(self, trained_model):
+        _, sprobs = run_inference_iohmm(
+            OBS_SYNTH, SIDE_INFO_SYNTH, trained_model,
+        )
+        row_sums = sprobs.sum(axis=1)
+        np.testing.assert_allclose(
+            row_sums, np.ones(T_SYNTH),
+            atol=1e-10,
+        )
+
+    def test_state_probs_nonnegative(self, trained_model):
+        _, sprobs = run_inference_iohmm(
+            OBS_SYNTH, SIDE_INFO_SYNTH, trained_model,
+        )
+        assert np.all(sprobs >= 0.0)
+
+    def test_works_on_new_data(self, trained_model):
+        """Inference should work on data not used for training."""
+        rng = np.random.default_rng(99)
+        T_new = 100
+        new_obs = rng.normal(0, 0.005, T_new)
+        new_side = np.linspace(0.3, 0.7, T_new)
+        preds, sprobs = run_inference_iohmm(new_obs, new_side, trained_model)
+        assert preds.shape == (T_new,)
+        assert sprobs.shape == (T_new, 2)
+        assert np.all(np.isfinite(preds))
+
+    def test_input_validation_length_mismatch(self, trained_model):
+        with pytest.raises(ValueError, match="same length"):
+            run_inference_iohmm(
+                np.array([1.0, 2.0]), np.array([1.0]), trained_model,
+            )
+
+    def test_input_validation_empty(self, trained_model):
+        with pytest.raises(ValueError, match="non-empty"):
+            run_inference_iohmm(
+                np.array([]), np.array([]), trained_model,
+            )
+
+
+# ── Integration ──────────────────────────────────────────────────────────────
+
+
+class TestIntegration:
+    def test_train_then_infer_end_to_end(self):
+        """Full pipeline: side info → spline → buckets → train → infer."""
+        rng = np.random.default_rng(123)
+        T = 400
+
+        # Two-regime data: low side info → negative returns, high → positive
+        side = np.linspace(0.2, 0.8, T)
+        obs = np.where(
+            side < 0.5,
+            rng.normal(-0.003, 0.004, T),
+            rng.normal(+0.003, 0.004, T),
+        )
+
+        model = train_iohmm(obs, side, K=2, n_knots=4, **FAST_BW)
+        preds, sprobs = run_inference_iohmm(obs, side, model)
+
+        assert preds.shape == (T,)
+        assert sprobs.shape == (T, 2)
+        assert np.all(np.isfinite(preds))
+        assert np.all(np.isfinite(sprobs))
+        # State probs sum to 1
+        np.testing.assert_allclose(sprobs.sum(axis=1), np.ones(T), atol=1e-10)
+
+    def test_single_bucket_degeneracy(self):
+        """If spline has no roots → 1 bucket → IOHMM degenerates to HMM."""
+        rng = np.random.default_rng(77)
+        T = 300
+        # Constant returns → flat spline → likely 1 bucket
+        obs = rng.normal(0, 0.005, T)
+        side = np.linspace(0.3, 0.7, T)
+
+        model = train_iohmm(obs, side, K=2, n_knots=4, **FAST_BW)
+
+        # Even with 1 bucket, everything should work
+        preds, sprobs = run_inference_iohmm(obs, side, model)
+        assert preds.shape == (T,)
+        assert sprobs.shape == (T, 2)
+        assert np.all(np.isfinite(preds))
+
+    def test_side_info_outside_training_range(self):
+        """Side info values outside training range should be handled."""
+        rng = np.random.default_rng(55)
+        T = 300
+        obs = rng.normal(0, 0.005, T)
+        side_train = np.linspace(0.3, 0.7, T)
+
+        model = train_iohmm(obs, side_train, K=2, n_knots=4, **FAST_BW)
+
+        # Inference with side info outside training range
+        side_test = np.linspace(0.0, 1.0, T)  # wider range
+        preds, sprobs = run_inference_iohmm(obs, side_test, model)
+        assert np.all(np.isfinite(preds))
+        assert np.all(np.isfinite(sprobs))

--- a/tests/test_iohmm.py
+++ b/tests/test_iohmm.py
@@ -8,6 +8,7 @@ from src.hmm.iohmm import (
     run_inference_iohmm,
     train_iohmm,
 )
+from src.hmm.side_info import spline_buckets
 
 # ── Shared fixtures ──────────────────────────────────────────────────────────
 
@@ -261,3 +262,101 @@ class TestIntegration:
         preds, sprobs = run_inference_iohmm(obs, side_test, model)
         assert np.all(np.isfinite(preds))
         assert np.all(np.isfinite(sprobs))
+
+    def test_K1_degenerate(self):
+        """K=1: single state → predictions always equal mu[0], state_probs always 1."""
+        rng = np.random.default_rng(88)
+        T = 200
+        obs = rng.normal(0, 0.005, T)
+        side = np.linspace(0.3, 0.7, T)
+
+        model = train_iohmm(obs, side, K=1, n_knots=4, **FAST_BW)
+        preds, sprobs = run_inference_iohmm(obs, side, model)
+
+        # All state probs must be 1.0 (only one state)
+        np.testing.assert_allclose(sprobs, np.ones((T, 1)), atol=1e-10)
+        # All predictions must equal the single emission mean
+        for r in range(model["R"]):
+            mu_r = model["bucket_params"][r]["mu"][0]
+            mask = np.searchsorted(model["boundaries"], side, side="right") == r
+            if np.any(mask):
+                np.testing.assert_allclose(
+                    preds[mask], mu_r,
+                    atol=1e-12,
+                    err_msg=f"bucket {r}: predictions != mu[0]",
+                )
+
+    def test_predict_before_update_causal(self):
+        """predictions[t] must use omega_pred (before update), not omega (after).
+
+        For K=1, predictions[t] = mu[0] regardless of observations — this
+        verifies the predict step uses the predicted distribution, not the
+        posterior.
+        """
+        rng = np.random.default_rng(33)
+        T = 100
+        # Use extreme observations that would shift a posterior if misused
+        obs = rng.normal(10.0, 0.001, T)
+        side = np.linspace(0.3, 0.7, T)
+
+        model = train_iohmm(obs, side, K=1, n_knots=4, **FAST_BW)
+        preds, _ = run_inference_iohmm(obs, side, model)
+
+        # With K=1, predictions must equal the bucket's mu[0] exactly
+        for t in range(T):
+            r_t = int(np.searchsorted(model["boundaries"], side[t], side="right"))
+            r_t = min(r_t, model["R"] - 1)
+            expected = model["bucket_params"][r_t]["mu"][0]
+            assert preds[t] == pytest.approx(expected, abs=1e-12), (
+                f"t={t}: prediction {preds[t]} != mu[0]={expected}"
+            )
+
+    def test_bucket_assignment_consistency(self):
+        """Bucket assignments in inference must match spline_buckets from training."""
+        model = train_iohmm(
+            OBS_SYNTH, SIDE_INFO_SYNTH, K=2, n_knots=4, **FAST_BW,
+        )
+        # Re-derive bucket assignments the same way training does
+        _, train_bucket_idx = spline_buckets(model["spline"], SIDE_INFO_SYNTH)
+
+        # Inference uses np.searchsorted(boundaries, side_info, side="right")
+        infer_bucket_idx = np.searchsorted(
+            model["boundaries"], SIDE_INFO_SYNTH, side="right",
+        )
+        np.testing.assert_array_equal(train_bucket_idx, infer_bucket_idx)
+
+    def test_iohmm_params_validation_missing_keys(self):
+        """run_inference_iohmm should raise on missing keys."""
+        obs = np.array([1.0, 2.0, 3.0])
+        side = np.array([0.3, 0.5, 0.7])
+        with pytest.raises(ValueError, match="missing keys"):
+            run_inference_iohmm(obs, side, {"K": 2})
+
+    def test_iohmm_params_validation_length_mismatch(self):
+        """run_inference_iohmm should raise if bucket_params length != R."""
+        obs = np.array([1.0, 2.0, 3.0])
+        side = np.array([0.3, 0.5, 0.7])
+        bad_params = {
+            "boundaries": np.array([0.5]),
+            "bucket_params": [{"A": np.eye(2), "pi": np.array([0.5, 0.5]),
+                               "mu": np.array([0.0, 0.0]), "sigma2": np.array([1.0, 1.0])}],
+            "K": 2,
+            "R": 2,  # R=2 but only 1 bucket_params entry
+        }
+        with pytest.raises(ValueError, match="bucket_params length"):
+            run_inference_iohmm(obs, side, bad_params)
+
+    def test_fallback_buckets_are_independent_copies(self):
+        """Each fallback bucket should own its own arrays (no shared references)."""
+        model = train_iohmm(
+            OBS_SYNTH, SIDE_INFO_SYNTH, K=2, n_knots=4,
+            min_obs_per_bucket=T_SYNTH + 1,  # force all fallback
+            **FAST_BW,
+        )
+        if model["R"] >= 2:
+            # Mutate bucket 0's mu — bucket 1 should be unaffected
+            original_mu_1 = model["bucket_params"][1]["mu"].copy()
+            model["bucket_params"][0]["mu"][:] = 999.0
+            np.testing.assert_array_equal(
+                model["bucket_params"][1]["mu"], original_mu_1,
+            )

--- a/tests/test_side_info.py
+++ b/tests/test_side_info.py
@@ -1,0 +1,243 @@
+"""Tests for side information features — vol ratio + seasonality (Paper §4)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.hmm.side_info import (
+    evaluate_spline,
+    ewma_volatility,
+    fit_spline,
+    seasonality_feature,
+    spline_buckets,
+    volatility_ratio,
+)
+
+
+# ── ewma_volatility ──────────────────────────────────────────────────────────
+
+
+class TestEwmaVolatility:
+    def test_recursion_matches_formula(self):
+        """EWMA recursion σ²_{t+1} = λ·σ²_t + (1-λ)·Δy²_t matches closed form."""
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0, 0.01, size=100)
+        lam = 0.79
+        sigma = ewma_volatility(returns, lam=lam)
+
+        # Manual recursion
+        sigma2_manual = np.empty(100)
+        sigma2_manual[0] = returns[0] ** 2
+        for t in range(1, 100):
+            sigma2_manual[t] = lam * sigma2_manual[t - 1] + (1 - lam) * returns[t] ** 2
+
+        np.testing.assert_allclose(
+            sigma ** 2, sigma2_manual,
+            rtol=np.finfo(float).eps * 100,
+        )
+
+    def test_output_positive(self):
+        """Volatility estimates must be non-negative."""
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0, 0.01, size=500)
+        sigma = ewma_volatility(returns)
+        assert np.all(sigma >= 0)
+
+    def test_higher_lambda_smoother(self):
+        """Higher λ → smoother vol estimates (lower variance of σ series)."""
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0, 0.01, size=500)
+        sigma_low = ewma_volatility(returns, lam=0.5)
+        sigma_high = ewma_volatility(returns, lam=0.95)
+        assert np.std(sigma_high) < np.std(sigma_low)
+
+    def test_constant_returns(self):
+        """Constant returns → σ converges to |return|."""
+        r = 0.01
+        returns = np.full(200, r)
+        sigma = ewma_volatility(returns, lam=0.79)
+        # Should converge to sqrt((1-λ)·r²/(1-λ)) = |r|
+        assert sigma[-1] == pytest.approx(abs(r), rel=0.01)
+
+    def test_invalid_lambda(self):
+        with pytest.raises(ValueError, match="lam"):
+            ewma_volatility(np.array([1.0]), lam=0.0)
+        with pytest.raises(ValueError, match="lam"):
+            ewma_volatility(np.array([1.0]), lam=1.0)
+
+    def test_empty_returns(self):
+        with pytest.raises(ValueError, match="at least 1"):
+            ewma_volatility(np.array([]))
+
+
+# ── volatility_ratio ──────────────────────────────────────────────────────────
+
+
+class TestVolatilityRatio:
+    def test_ratio_in_reasonable_range(self):
+        """Vol ratio should be in (0, ∞), typically near 1.0."""
+        rng = np.random.default_rng(42)
+        returns = rng.normal(0, 0.01, size=500)
+        ratio = volatility_ratio(returns)
+        assert np.all(ratio > 0)
+        assert np.all(np.isfinite(ratio))
+        # Stationary returns: ratio should be near 1.0
+        assert np.median(ratio) == pytest.approx(1.0, abs=0.3)
+
+    def test_decreasing_vol_gives_low_ratio(self):
+        """When recent vol drops, short EWMA reacts faster → ratio < 1."""
+        rng = np.random.default_rng(42)
+        # High vol then sudden drop — short window adapts faster
+        returns = np.concatenate([
+            rng.normal(0, 0.05, 300),
+            rng.normal(0, 0.001, 300),  # vol drops 50x
+        ])
+        ratio = volatility_ratio(returns, window_short=50, window_long=100)
+        # After the drop, short vol falls faster → ratio < 1
+        # With λ=0.79, effective memory ~5 bars, so check right after transition
+        # The long window retains more high-vol memory than the short window
+        assert np.min(ratio[300:310]) < 1.0
+
+    def test_invalid_window_order(self):
+        with pytest.raises(ValueError, match="window_short"):
+            volatility_ratio(np.array([1.0] * 200), window_short=100, window_long=50)
+
+
+# ── seasonality_feature ───────────────────────────────────────────────────────
+
+
+class TestSeasonalityFeature:
+    def test_range_0_to_1(self):
+        """Feature values should be in [0, 1]."""
+        timestamps = pd.date_range("2024-01-02 09:30", periods=390, freq="1min")
+        feat = seasonality_feature(timestamps)
+        assert np.all(feat >= 0.0)
+        assert np.all(feat <= 1.0)
+
+    def test_monotonic_within_day(self):
+        """Feature should increase monotonically within a single trading day."""
+        timestamps = pd.date_range("2024-01-02 09:30", periods=390, freq="1min")
+        feat = seasonality_feature(timestamps)
+        assert np.all(np.diff(feat) >= 0)
+
+    def test_output_length(self):
+        timestamps = pd.date_range("2024-01-02 09:30", periods=100, freq="1min")
+        feat = seasonality_feature(timestamps)
+        assert len(feat) == 100
+
+
+# ── fit_spline + evaluate_spline ──────────────────────────────────────────────
+
+
+class TestSpline:
+    def test_spline_fits_known_function(self):
+        """Spline should approximate a known non-linear function."""
+        rng = np.random.default_rng(42)
+        x = np.linspace(0, 1, 500)
+        # True function: sine wave
+        y_true = 0.1 * np.sin(2 * np.pi * x) + rng.normal(0, 0.01, 500)
+        spline = fit_spline(x, y_true, n_knots=6)
+        y_pred = evaluate_spline(spline, x)
+        # Should track the sine wave; residual σ should be near noise level
+        residual_std = np.std(y_pred - 0.1 * np.sin(2 * np.pi * x))
+        assert residual_std < 0.05  # much less than signal amplitude 0.1
+
+    def test_spline_is_zero_mean(self):
+        """Spline integral should be ~zero (Paper §4.1)."""
+        rng = np.random.default_rng(42)
+        x = np.linspace(0, 1, 1000)
+        y = 0.05 * np.sin(4 * np.pi * x) + rng.normal(0, 0.01, 1000)
+        spline = fit_spline(x, y, n_knots=10)
+        # Evaluate on dense grid and check mean ≈ 0
+        x_eval = np.linspace(x.min(), x.max(), 5000)
+        spline_mean = np.mean(spline(x_eval))
+        assert abs(spline_mean) < 0.01
+
+    def test_evaluate_clips_to_domain(self):
+        """Evaluation outside training domain should clip, not extrapolate."""
+        rng = np.random.default_rng(42)
+        x = np.linspace(0.1, 0.9, 200)
+        y = rng.normal(0, 0.01, 200)
+        spline = fit_spline(x, y, n_knots=4)
+        # Evaluate outside domain
+        x_outside = np.array([-1.0, 0.0, 0.5, 1.0, 2.0])
+        result = evaluate_spline(spline, x_outside)
+        assert np.all(np.isfinite(result))
+
+    def test_spline_with_6_knots(self):
+        """Paper uses 6 knots for vol ratio — should work."""
+        rng = np.random.default_rng(42)
+        x = np.linspace(0.5, 1.0, 300)
+        y = rng.normal(0, 0.01, 300)
+        spline = fit_spline(x, y, n_knots=6)
+        result = evaluate_spline(spline, x)
+        assert result.shape == (300,)
+        assert np.all(np.isfinite(result))
+
+    def test_invalid_lengths(self):
+        with pytest.raises(ValueError, match="same length"):
+            fit_spline(np.array([1.0, 2.0]), np.array([1.0]))
+
+    def test_too_few_observations(self):
+        with pytest.raises(ValueError, match="Need at least"):
+            fit_spline(np.array([1.0, 2.0]), np.array([1.0, 2.0]), n_knots=10)
+
+
+# ── spline_buckets ────────────────────────────────────────────────────────────
+
+
+class TestSplineBuckets:
+    def test_sine_spline_has_roots(self):
+        """Sine-like spline should produce roots and multiple buckets."""
+        rng = np.random.default_rng(42)
+        x = np.linspace(0, 1, 500)
+        y = 0.1 * np.sin(2 * np.pi * x) + rng.normal(0, 0.01, 500)
+        spline = fit_spline(x, y, n_knots=6)
+        boundaries, bucket_idx = spline_buckets(spline, x)
+        assert len(boundaries) >= 1  # At least 1 root
+        R = len(boundaries) + 1
+        assert R >= 2
+        assert bucket_idx.min() == 0
+        assert bucket_idx.max() == R - 1
+
+    def test_all_observations_assigned(self):
+        """Every observation must get a bucket index."""
+        rng = np.random.default_rng(42)
+        x = np.linspace(0, 1, 300)
+        y = 0.05 * np.sin(4 * np.pi * x) + rng.normal(0, 0.01, 300)
+        spline = fit_spline(x, y, n_knots=8)
+        _, bucket_idx = spline_buckets(spline, x)
+        assert len(bucket_idx) == 300
+        assert np.all(bucket_idx >= 0)
+
+    def test_flat_spline_gives_one_bucket(self):
+        """Constant returns → flat spline → no roots → 1 bucket."""
+        x = np.linspace(0, 1, 200)
+        y = np.zeros(200)  # Flat
+        spline = fit_spline(x, y, n_knots=4)
+        boundaries, bucket_idx = spline_buckets(spline, x)
+        # Flat spline ≈ 0 everywhere → may have 0 or many "roots"
+        # With zero-mean correction on zero data, spline ≈ 0
+        # All observations should still be assigned
+        assert len(bucket_idx) == 200
+
+    def test_bucket_indices_are_valid(self):
+        """Bucket indices should be in [0, R-1]."""
+        rng = np.random.default_rng(42)
+        x = np.linspace(0.5, 1.0, 400)
+        y = 0.1 * np.sin(3 * np.pi * x) + rng.normal(0, 0.01, 400)
+        spline = fit_spline(x, y, n_knots=6)
+        boundaries, bucket_idx = spline_buckets(spline, x)
+        R = len(boundaries) + 1
+        assert np.all(bucket_idx >= 0)
+        assert np.all(bucket_idx < R)
+
+    def test_boundaries_are_sorted(self):
+        """Spline roots (boundaries) should be sorted."""
+        rng = np.random.default_rng(42)
+        x = np.linspace(0, 1, 500)
+        y = 0.1 * np.sin(2 * np.pi * x) + rng.normal(0, 0.01, 500)
+        spline = fit_spline(x, y, n_knots=6)
+        boundaries, _ = spline_buckets(spline, x)
+        if len(boundaries) > 1:
+            assert np.all(np.diff(boundaries) > 0)


### PR DESCRIPTION
## Summary
- **Side info features** (`src/hmm/side_info.py`, #75): EWMA/IGARCH volatility (λ=0.79), vol ratio (Ω_fast=50/Ω_slow=100), intraday seasonality, B-spline fitting with zero-mean constraint, spline-root bucket assignment
- **IOHMM training** (`src/hmm/iohmm.py`, #76): Bucket-based Baum-Welch — fit spline to (side_info, returns), find roots → R buckets, train separate HMM per bucket via `train_hmm_numba`
- **IOHMM inference** (`src/hmm/iohmm.py`, #77): Online predict-update filter with bucket-switching — at each t, look up bucket r_t from side info, use Θ_{r_t} for that step (Paper §6, Algorithm 5)

## Tests
- `tests/test_side_info.py`: 23 tests (EWMA recursion, vol ratio, seasonality, spline fitting/roots)
- `tests/test_iohmm.py`: 27 tests (training validation, inference correctness, K=1 degenerate, causal ordering, bucket consistency, input validation)

## Review fixes applied
- Copy fallback params to avoid shared-reference mutation
- Validate `iohmm_params` dict structure in `run_inference_iohmm`
- Document `predictions[0]` prior-prediction semantics
- Use `ll[0]` not `ll[-1]` (single-element history list)

Closes #75, closes #76, closes #77

## Test plan
- [x] All 50 tests pass (23 side_info + 27 IOHMM)
- [x] K=1, K=2, K=3 degenerate cases tested
- [x] Causal predict-before-update verified
- [x] Bucket assignment consistency between training and inference verified
- [x] Code review completed — all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)